### PR TITLE
CKS-280 Add Strict-Transport-Security header

### DIFF
--- a/nginx/geoip/geoip
+++ b/nginx/geoip/geoip
@@ -23,5 +23,6 @@ location / {
     proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
     proxy_set_header Host $http_host;
     proxy_set_header X-Forwarded-Proto https;
+    add_header Strict-Transport-Security "max-age=31536000; includeSubDomains" always;
     proxy_pass $upstream;
 }


### PR DESCRIPTION
https://nicedigital.atlassian.net/browse/CKS-280

I've used a year for the HSTS max-age, because ([from the .NET docs](https://docs.microsoft.com/en-us/aspnet/core/security/enforcing-ssl?view=aspnetcore-2.1&tabs=visual-studio#http-strict-transport-security-protocol-hsts)):

> After you're confident in the sustainability of the HTTPS configuration, increase the HSTS max-age value; a commonly used value is one year.