### PR TITLE
Allow HotJar and Chrome lighthouse

### DIFF
--- a/nginx/geoip/geoip
+++ b/nginx/geoip/geoip
@@ -7,7 +7,7 @@ location / {
         rewrite ^ https://$host$request_uri? permanent;
     }
     set $disallow 1;
-    if ($http_user_agent ~* googlebot|yahoo|bingbot|baiduspider|yandex|yeti|yodaobot|gigabot|ia_archiver|facebookexternalhit|twitterbot|developers\.google\.com|pingdom) {
+    if ($http_user_agent ~* googlebot|yahoo|bingbot|baiduspider|yandex|yeti|yodaobot|gigabot|ia_archiver|facebookexternalhit|twitterbot|developers\.google\.com|pingdom|lighthouse|hotjar) {
         set $disallow 0;
     }
     if ($uk_request = yes) {


### PR DESCRIPTION
We've had problems with CSS not loading properly in HotJar recordings. HotJar uses the following User Agents:

// Desktop user agent:
  Mozilla/5.0 (Macintosh; Intel Mac OS X 10_14_3) AppleWebKit/537.36 (KHTML, like Gecko) Hotjar Chrome/74.0.3729.131 Safari/537.36
  // Tablet user agent:
  Mozilla/5.0 (iPad; CPU iPhone OS 11_3 like Mac OS X) AppleWebKit/605.1.15 (KHTML, like Gecko) Hotjar Version/11.0 Mobile/15E148 Safari/604.1
  // Phone user agent:
  Mozilla/5.0 (iPhone; CPU iPhone OS 11_3 like Mac OS X) AppleWebKit/605.1.15 (KHTML, like Gecko) Hotjar Version/11.0 Mobile/15E148 Safari/604.1

According to https://help.hotjar.com/hc/en-us/articles/115011713727. And this page: https://help.hotjar.com/hc/en-us/articles/115011822728-Troubleshooting-FAQs-for-Recordings#why-do-the-pages-look-brokenno-css-loading says allowing the user agent should fix the problem. 

Secondly, if you do a test on https://web.dev/measure/ for CKS, you see results for nice.org.uk because of the georestriction redirect. Web.dev uses the following user agent:

Mozilla/5.0 (Linux; Android 7.0; Moto G (4)) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/84.0.4143.7 Mobile Safari/537.36 Chrome-Lighthouse