### PR TITLE
Use http version 1.1 for talking to backend servers.

### DIFF
--- a/nginx/geoip/geoip
+++ b/nginx/geoip/geoip
@@ -19,6 +19,7 @@ location / {
     if ($disallow) {
         rewrite ^ $geo_redirect redirect;
     }
+    proxy_http_version 1.1;
     proxy_set_header X-Real-IP $remote_addr;
     proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
     proxy_set_header Host $http_host;


### PR DESCRIPTION
The ngx_http_proxy_module uses http 1.0 by default.
Version 1.1 is recommended: http://nginx.org/en/docs/http/ngx_http_proxy_module.html#proxy_http_version.
Using 1.1 also means nginx forwards the accept encoding to the backend,
as compression only works in HTTP 1.1.

This means we can use IIS dynamic compression on back end servers, as
IIS doesn't compress for HTTP 1.0 by default (the noCompressionForHttp10
config option is set to true by default) see https://docs.microsoft.com/en-us/iis/configuration/system.webserver/httpcompression/#attributes.